### PR TITLE
fix: error being raised due to incorrect frame being used

### DIFF
--- a/src/kimmdy_hydrolysis/reaction.py
+++ b/src/kimmdy_hydrolysis/reaction.py
@@ -208,7 +208,7 @@ class HydrolysisReaction(ReactionPlugin):
             f"Hydrolyzing bond between C with ix {ix_cc} and N with ix {ix_n} at time {ttime} ps"
         )
 
-        frame = int(ttime / self.ps_per_frame)
+        frame = round(ttime / self.ps_per_frame)
         snapshot = self.u.trajectory[frame]
 
         logger.info(


### PR DESCRIPTION
An error sometimes occur due to the presence of a time mismatch. This occurs when `ttime / self.ps_per_frame` calculates slightly under the nearest integer due to machine precision. When the integer is taken for this value, it gives the previous frame rather than the current frame.
 For example: `frame = int(13.2/0.2) = int(65.99999....) = 65` when it should be frame 66.
 I've proposed the fix of changing `int` to `round` to ensure the correct frame is computed.